### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 1.0.1   2 Sep 2017
+==========================
+* timestamp/s was converting the day to "Sat Sep 02 01:02:03 UTC 2017".  Amazon doesn't like the leading zero on the day.
+* renamed hex-hash to hash-hex-string, since every place hex-hash was used, it took a hex string as input, computed the
+  hash, which was then converted to an integer.
+* renamed sha256/hs as sha256/hs64 and return ensure the resulting string is at least 64 characters, padded with leading
+  '0's.
+
 Version 1.0.0, 24 Aug 2017
 ==========================
 * initial release

--- a/cl-cognito.asd
+++ b/cl-cognito.asd
@@ -30,7 +30,7 @@
   :description "Amazon Cognito Utilities"
   :author "Bob Felts <wrf3@stablecross.com>"
   :license "BSD"
-  :version "1.0.0"   
+  :version "1.1.0"   
   :depends-on (#:babel
                #:dexador
                #:cl-json


### PR DESCRIPTION
* `timestamp/s` was converting the day to "Sat Sep 02 01:02:03 UTC 2017".  Amazon doesn't like the leading zero on the day.
* renamed `hex-hash` to `hash-hex-string`, since every place `hex-hash` was used, it took a hex string as input and computed the hash which was then everywhere converted to an integer.
* renamed `sha256/hs` as `sha256/hs64` and ensured the resulting string was at least 64 characters, padded with leading '0's.
