### PR TITLE
Version 2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+Version 2.2 26 January 2018
+=============================
+* Added admin-delete-user
+* Parameter confirmation-code to confirm-forgot-password can be a number or a string
+
 Version 2.1 10 October 2017
 =============================
 * Added admin-create-user

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-;;; Copyright (c) 2017 William R. Felts III, All Rights Reserved
+;;; Copyright (c) 2017-2018 William R. Felts III, All Rights Reserved
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The nickname **cognito** can be used for the **cl-cognito** package.
 **confirm-forgot-password** (username confirmation-code new-password pool-id client-id &key (service "cognito-idp") (client-secret nil))
 
 		Change password to new-password.
+		confirmation-code can be an integer or a string (e.g. 307293 or "307293")
 		
 		=> result, code, response
 
@@ -157,9 +158,11 @@ The nickname **cognito** can be used for the **cl-cognito** package.
 	
 [Function]<br>
 **admin-create-user** (username pool-id temporary-password access-key secret-key<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-&key (service "cognito-idp") (delivery 'email) (force-alias nil)<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+key (service "cognito-idp") (delivery 'email) (force-alias nil)<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 (message-action 'suppress) (user-attributes nil) (validation-data nil))
 
 		delivery is 'email or 'sms or '(email sms)
@@ -249,6 +252,23 @@ The nickname **cognito** can be used for the **cl-cognito** package.
 		Returns t on success, nil on failure.  **code** and **response** can be used to
 		determine failure cause.
 
+[Function]<br>
+**admin-delete-user** (username pool-id access-key secret-key &key (service "cognito-idp"))
+
+		=> result, code, response
+		
+		Delete user from pool.  
+		
+		Example:
+		
+		(cognito:admin-delete-user "test-user" *pool-id*  *access-key* *secret-key*)
+		
+		=> T
+		   200
+		   NIL
+
+
+		
 #### BUGS
 
 The URL to use to interact with Cognito is constructed by the private function **(make-aws-url/s service\_s region\_s)**.<br>

--- a/cl-cognito.asd
+++ b/cl-cognito.asd
@@ -1,4 +1,4 @@
-;;; Copyright (c) 2017 William R. Felts III, All Rights Reserved
+;;; Copyright (c) 2017-2018 William R. Felts III, All Rights Reserved
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
   :description "Amazon Cognito Utilities"
   :author "Bob Felts <wrf3@stablecross.com>"
   :license "BSD"
-  :version "2.1"   
+  :version "2.2"   
   :depends-on (#:babel
                #:dexador
                #:cl-json

--- a/package.lisp
+++ b/package.lisp
@@ -1,4 +1,4 @@
-;;; Copyright (c) 2017 William R. Felts III, All Rights Reserved
+;;; Copyright (c) 2017-2018 William R. Felts III, All Rights Reserved
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
   (:nicknames #:cognito)
   (:export
    #:admin-create-user
+   #:admin-delete-user
    #:admin-get-user
    #:admin-reset-user-password
    #:admin-update-user-attributes


### PR DESCRIPTION
Added `admin-delete-user`.  Allow parameter `confirmation-code` to `confirm-forgot-password` to be a number or a string.